### PR TITLE
Fix flows._0Ucast

### DIFF
--- a/accton/accton_util.py
+++ b/accton/accton_util.py
@@ -1076,7 +1076,7 @@ def add_termination_flow(ctrl, in_port, eth_type, dst_mac, vlanid, goto_table=No
 
     return request
 
-def add_unicast_routing_flow(ctrl, eth_type, dst_ip, mask, action_group_id, vrf=0, send_ctrl=False, send_barrier=False):
+def add_unicast_routing_flow(ctrl, eth_type, dst_ip, mask, action_group_id, vrf=0, send_ctrl=False, send_barrier=False, priority = 1):
     match = ofp.match()
     match.oxm_list.append(ofp.oxm.eth_type(eth_type))
     if vrf != 0:
@@ -1100,7 +1100,7 @@ def add_unicast_routing_flow(ctrl, eth_type, dst_ip, mask, action_group_id, vrf=
             match=match,
             instructions=instructions,
             buffer_id=ofp.OFP_NO_BUFFER,
-            priority=1)
+            priority=priority)
 
     logging.info("Inserting unicast routing flow eth_type %lx, dip %ld",eth_type, dst_ip)
     ctrl.message_send(request)

--- a/ofdpa/flows.py
+++ b/ofdpa/flows.py
@@ -1860,7 +1860,7 @@ class _0Ucast( base_tests.SimpleDataPlane ):
                     add_termination_flow( self.controller, port, 0x0800, intf_src_mac, vlan_id )
                 # add unicast routing flow
                 dst_ip = dip + (vlan_id << 8)
-                add_unicast_routing_flow( self.controller, 0x0800, dst_ip, 0xffffffff, l3_msg.group_id )
+                add_unicast_routing_flow( self.controller, 0x0800, dst_ip, 0xffffffff, l3_msg.group_id, priority=2 )
                 Groups.put( l2gid )
                 Groups.put( l3_msg.group_id )
             l3_gid = encode_l3_unicast_group_id( ports[ 0 ] )


### PR DESCRIPTION
Modified add_unicast_routing_flow to assign arbitrary priority to the flow.

That is required to resolve possible issue with flows._0Ucast,
when less-defined flow is matched instead of more defined.

In case of equivalent matches the exact match chosen is undefined.
In the flows._0Ucast TC it is expected that more defined match has higher priority than less defined.
